### PR TITLE
Fixed atecc library and function reference typo

### DIFF
--- a/Blinky-Hello-World/main/main.c
+++ b/Blinky-Hello-World/main/main.c
@@ -51,7 +51,7 @@
 #include "axp192.h"
 #include "cryptoauthlib.h"
 #include "i2c_device.h"
-#include "atecc608.h"
+#include "atecc608a.h"
 
 #include "aws_iot_config.h"
 #include "aws_iot_log.h"
@@ -225,7 +225,7 @@ void aws_iot_task(void *param) {
     mqttInitParams.pDevicePrivateKeyLocation = "#0";
     
     char * clientId = malloc(ATCA_SERIAL_NUM_SIZE * 2 + 1);
-    ATCA_STATUS ret = Atecc608_GetSerialString(clientId);
+    ATCA_STATUS ret = Atecc608a_GetSerialString(clientId);
     if (ret != ATCA_SUCCESS){
         ESP_LOGE(TAG, "Failed to get device serial from secure element. Error: %i", ret);
         abort();
@@ -429,7 +429,7 @@ void app_main()
     initialise_wifi();
 
     #if defined (CONFIG_AWS_IOT_USE_HARDWARE_SECURE_ELEMENT)
-        ATCA_STATUS ret = Atecc608_Init();
+        ATCA_STATUS ret = Atecc608a_Init();
         if (ret != ATCA_SUCCESS){
             ESP_LOGE(TAG, "ATECC608 secure element initialization error!");
             abort();


### PR DESCRIPTION
It seems that there is a typo in the latest branch updated a few hours ago.

This issue prevents the code to compile as it can't find the header file and the existing header file does not have matching function names.
