### PR TITLE
Fixed Hardware-features-demo build failure on Linux

### DIFF
--- a/Hardware-Features-Demo/main/mic_fft_test.c
+++ b/Hardware-Features-Demo/main/mic_fft_test.c
@@ -7,7 +7,7 @@
 
 #include "math.h"
 #include "fft.h"
-#include "core2foraws.h"
+#include "core2forAWS.h"
 #include "lvgl/lvgl.h"
 #include "driver/i2s.h"
 #include "microphone.h"


### PR DESCRIPTION
fixed include core2forAWS.h typo in file mic_fft_test.c  that caused Hardware-features-demo build to fail on Ubuntu 20.04.