### PR TITLE
Fix "Register I2S Interrupt error" for some devices when using example code

### DIFF
--- a/Blinky-Hello-World/components/core2forAWS/microphone/microphone.c
+++ b/Blinky-Hello-World/components/core2forAWS/microphone/microphone.c
@@ -18,7 +18,7 @@ void Microphone_Init() {
 #else
 		.communication_format = I2S_COMM_FORMAT_I2S,
 #endif
-        .intr_alloc_flags = ESP_INTR_FLAG_LEVEL1,
+        .intr_alloc_flags = ESP_INTR_FLAG_LEVEL2,
         .dma_buf_count = 2,
         .dma_buf_len = 128,
     };

--- a/Blinky-Hello-World/components/core2forAWS/speaker/speaker.c
+++ b/Blinky-Hello-World/components/core2forAWS/speaker/speaker.c
@@ -21,7 +21,7 @@ void Speaker_Init() {
 #else
         .communication_format = I2S_COMM_FORMAT_I2S,
 #endif
-        .intr_alloc_flags = ESP_INTR_FLAG_LEVEL1,
+        .intr_alloc_flags = ESP_INTR_FLAG_LEVEL2,
         .dma_buf_count = 2,
         .dma_buf_len = 128,
     };


### PR DESCRIPTION
When using the [microphone](https://edukit.workshop.aws/en/api-reference/spm1423.html) and [speaker](https://edukit.workshop.aws/en/api-reference/speaker.html) example code, my unit would bootloop with the following errors (output from serial over USB):

␛[0;31mE (2852) I2S: Register I2S Interrupt error␛[0m
Guru Meditation Error: Core 0 panic'ed (LoadProhibited). Exception was unhandled.

After some investigation I was able to determine that modifications to microphone.c and speaker.c resolve my issue. I suspect that as others start to get their devices, there may be some one-offs that have this same issue. 

(.intr_alloc_flags = ESP_INTR_FLAG_LEVEL1 -> .intr_alloc_flags = ESP_INTR_FLAG_LEVEL2)

I guess something about my unit just doesn't like using the lowest interrupt level. Not sure what other consequences of these modifications are, but they fixed my boot loop issues. 